### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn GitHub fundamentals including version control, collaboration, and open source workflows. Part of our GitHub Certifications program.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing "GitHub Skills" activity to the school activities signup page.

## Changes
- Added new "GitHub Skills" activity with:
  - Description highlighting GitHub fundamentals, version control, collaboration, and open source workflows
  - Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - Maximum 25 participants
  - Part of the GitHub Certifications program

## Closes
Fixes #6 

## Context
This activity was announced by the principal at the school assembly as part of a new partnership with GitHub. Registration closes by end of this week, so this is time-sensitive.